### PR TITLE
fix(ci): remove golangci-lint version

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,7 +31,6 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@9938e103f8065deff3f289d9e975270d5541b866
         with:
-          version: v1.64.5
           args: --timeout=5m
 
       - name: Format Go code


### PR DESCRIPTION
Defer to using latest version