### PR TITLE
Add Copy Buttons to Input and Result Fields

### DIFF
--- a/cmd/server/static/styles.css
+++ b/cmd/server/static/styles.css
@@ -1,309 +1,430 @@
 /* ==========================================================================
    Reset and Base Styles
    ========================================================================== */
-   * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
 body {
-    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    background-color: #f0f2f5;
-    color: #333;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    min-height: 100vh;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background-color: #f0f2f5;
+  color: #333;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
 }
 
 /* ==========================================================================
    Layout
    ========================================================================== */
 .app-container {
-    max-width: 600px;
-    width: 100%;
-    background: #ffffff;
-    padding: 2rem;
-    border-radius: 12px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+  max-width: 600px;
+  width: 100%;
+  background: #ffffff;
+  padding: 2rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 /* ==========================================================================
    Typography
    ========================================================================== */
 .app-title {
-    font-size: 2rem;
-    font-weight: 700;
-    color: #1a73e8;
-    margin-bottom: 1rem;
-    text-align: center;
+  font-size: 2rem;
+  font-weight: 700;
+  color: #1a73e8;
+  margin-bottom: 1rem;
+  text-align: center;
 }
 
 .app-description {
-    font-size: 1rem;
-    color: #666;
-    margin-bottom: 1.5rem;
-    text-align: center;
+  font-size: 1rem;
+  color: #666;
+  margin-bottom: 1.5rem;
+  text-align: center;
 }
 
 /* ==========================================================================
    Form Elements
    ========================================================================== */
 .form-fields {
-    display: grid;
+  display: grid;
 }
 
 .form-field {
-    width: 100%;
-    padding: 0.75rem 1rem;
-    font-size: 1rem;
-    border: 1px solid #ddd;
-    border-radius: 6px;
-    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
 }
 
 .form-field:focus {
-    border-color: #1a73e8;
-    box-shadow: 0 0 8px rgba(26, 115, 232, 0.2);
-    outline: none;
+  border-color: #1a73e8;
+  box-shadow: 0 0 8px rgba(26, 115, 232, 0.2);
+  outline: none;
 }
 
 .form-label {
-    display: block;
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: #444;
-    margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #444;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .form-buttons {
-    display: flex;
-    justify-content: center;
-    gap: 1rem; /* Space between buttons */
-    margin-top: 1rem; /* Increased margin to ensure spacing from the input above */
+  display: flex;
+  justify-content: center;
+  gap: 1rem; /* Space between buttons */
+  margin-top: 1rem; /* Increased margin to ensure spacing from the input above */
 }
 
 .form-submit {
-    display: inline-block;
-    padding: 0.75rem 1.5rem; /* Increased padding to make the button larger */
-    font-size: 1rem; /* Increased font size for better readability */
-    font-weight: 600;
-    color: #fff;
-    background: linear-gradient(135deg, #1a73e8, #0d47a1);
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    transition: background 0.3s ease, transform 0.2s ease;
-    width: auto; /* Ensure the button doesn't stretch too wide */
-    transform: translateX(-10px); /* Offset centered left */
+  display: inline-block;
+  padding: 0.75rem 1.5rem; /* Increased padding to make the button larger */
+  font-size: 1rem; /* Increased font size for better readability */
+  font-weight: 600;
+  color: #fff;
+  background: linear-gradient(135deg, #1a73e8, #0d47a1);
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.3s ease, transform 0.2s ease;
+  width: auto; /* Ensure the button doesn't stretch too wide */
+  transform: translateX(-10px); /* Offset centered left */
 }
 
 .form-submit:hover {
-    background: linear-gradient(135deg, #1557b0, #08306b);
-    transform: translateY(-2px) translateX(-10px); /* Maintain offset on hover */
+  background: linear-gradient(135deg, #1557b0, #08306b);
+  transform: translateY(-2px) translateX(-10px); /* Maintain offset on hover */
 }
 
 .form-submit:active {
-    transform: translateY(0) translateX(-10px); /* Maintain offset on active */
+  transform: translateY(0) translateX(-10px); /* Maintain offset on active */
 }
 
 .form-clear {
-    display: inline-block;
-    padding: 0.75rem 1.5rem; /* Match form-submit size */
-    font-size: 1rem;
-    font-weight: 600;
-    color: #fff;
-    background: linear-gradient(135deg, #f44336, #b71c1c); /* Red color scheme for clear */
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    transition: background 0.3s ease, transform 0.2s ease;
-    width: auto;
-    transform: translateX(10px); /* Offset centered right to balance form-submit */
+  display: inline-block;
+  padding: 0.75rem 1.5rem; /* Match form-submit size */
+  font-size: 1rem;
+  font-weight: 600;
+  color: #fff;
+  background: linear-gradient(
+    135deg,
+    #f44336,
+    #b71c1c
+  ); /* Red color scheme for clear */
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.3s ease, transform 0.2s ease;
+  width: auto;
+  transform: translateX(
+    10px
+  ); /* Offset centered right to balance form-submit */
 }
 
 .form-clear:hover {
-    background: linear-gradient(135deg, #d32f2f, #8c1515);
-    transform: translateY(-2px) translateX(10px); /* Maintain offset on hover */
+  background: linear-gradient(135deg, #d32f2f, #8c1515);
+  transform: translateY(-2px) translateX(10px); /* Maintain offset on hover */
 }
 
 .form-clear:active {
-    transform: translateY(0) translateX(10px); /* Maintain offset on active */
+  transform: translateY(0) translateX(10px); /* Maintain offset on active */
 }
 
 /* ==========================================================================
    Result and Error Messages
    ========================================================================== */
 .form-results.hidden {
-    display: none;
+  display: none;
 }
 
 .form-results .result-container {
-    min-height: 50px; /* Ensure space for content */
+  min-height: 50px; /* Ensure space for content */
 }
 
 .form-results .result-container.hidden {
-    display: none;
+  display: none;
 }
 
 .form-results .result-container label {
-    display: block;
-    margin-bottom: 0.5rem;
+  display: block;
+  margin-bottom: 0.5rem;
 }
 
 .hidden {
-    display: none;
+  display: none;
 }
 
 .error-message {
-    color: #d32f2f;
-    font-size: 0.9rem;
-    margin-top: 0.5rem;
-    text-align: center;
+  color: #d32f2f;
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+  text-align: center;
 }
 
 /* ==========================================================================
    Loading Spinner
    ========================================================================== */
 .htmx-request .result-container::before {
-    content: '';
-    display: block;
-    width: 20px;
-    height: 20px;
-    margin: 1rem auto;
-    border: 3px solid #1a73e8;
-    border-top: 3px solid transparent;
-    border-radius: 50%;
-    animation: spin 0.6s linear infinite;
+  content: "";
+  display: block;
+  width: 20px;
+  height: 20px;
+  margin: 1rem auto;
+  border: 3px solid #1a73e8;
+  border-top: 3px solid transparent;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
 }
 
 .htmx-settling .result-container::before,
 .htmx-request .result-container::before {
-    content: none;
+  content: none;
 }
 
 @keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 /* ==========================================================================
    Responsive Design
    ========================================================================== */
 @media (max-width: 480px) {
-    body {
-        padding: 10px;
-    }
+  body {
+    padding: 10px;
+  }
 
-    .app-container {
-        padding: 1.5rem;
-    }
+  .app-container {
+    padding: 1.5rem;
+  }
 
-    .app-title {
-        font-size: 1.5rem;
-    }
+  .app-title {
+    font-size: 1.5rem;
+  }
 
-    .app-description {
-        font-size: 0.9rem;
-    }
+  .app-description {
+    font-size: 0.9rem;
+  }
 
-    .form-field, .form-submit, .form-clear {
-        font-size: 0.9rem;
-    }
+  .form-field,
+  .form-submit,
+  .form-clear {
+    font-size: 0.9rem;
+  }
 
-    .form-buttons {
-        flex-direction: column;
-        gap: 0.5rem; /* Reduce gap on smaller screens */
-    }
+  .form-buttons {
+    flex-direction: column;
+    gap: 0.5rem; /* Reduce gap on smaller screens */
+  }
 
-    .form-submit, .form-clear {
-        transform: none; /* Remove offset on smaller screens */
-    }
+  .form-submit,
+  .form-clear {
+    transform: none; /* Remove offset on smaller screens */
+  }
 
-    .form-submit:hover, .form-clear:hover {
-        transform: translateY(-2px); /* Maintain hover effect */
-    }
+  .form-submit:hover,
+  .form-clear:hover {
+    transform: translateY(-2px); /* Maintain hover effect */
+  }
 
-    .form-submit:active, .form-clear:active {
-        transform: translateY(0); /* Maintain active effect */
-    }
+  .form-submit:active,
+  .form-clear:active {
+    transform: translateY(0); /* Maintain active effect */
+  }
 }
 
 /* ==========================================================================
    Accessibility Enhancements
    ========================================================================== */
 @media (prefers-reduced-motion: reduce) {
-    .app-container, .form-submit, .form-field, .form-clear {
-        transition: none;
-    }
+  .app-container,
+  .form-submit,
+  .form-field,
+  .form-clear {
+    transition: none;
+  }
 }
 
-.form-submit:focus, .form-field:focus, .form-clear:focus {
-    outline: 3px solid #1a73e8;
-    outline-offset: 2px;
+.form-submit:focus,
+.form-field:focus,
+.form-clear:focus {
+  outline: 3px solid #1a73e8;
+  outline-offset: 2px;
 }
 
 /* ==========================================================================
    Dark Mode
    ========================================================================== */
 @media (prefers-color-scheme: dark) {
-    body {
-        background-color: #1a1a1a;
-        color: #e0e0e0;
-    }
+  body {
+    background-color: #1a1a1a;
+    color: #e0e0e0;
+  }
 
-    .app-container {
-        background: #2a2a2a;
-        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
-    }
+  .app-container {
+    background: #2a2a2a;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  }
 
-    .app-title {
-        color: #4dabf7;
-    }
+  .app-title {
+    color: #4dabf7;
+  }
 
-    .app-description {
-        color: #b0b0b0;
-    }
+  .app-description {
+    color: #b0b0b0;
+  }
 
-    .form-field {
-        background-color: #333;
-        border-color: #444;
-        color: #e0e0e0;
-    }
+  .form-field {
+    background-color: #333;
+    border-color: #444;
+    color: #e0e0e0;
+  }
 
-    .form-field:focus {
-        border-color: #4dabf7;
-        box-shadow: 0 0 8px rgba(77, 171, 247, 0.3);
-    }
+  .form-field:focus {
+    border-color: #4dabf7;
+    box-shadow: 0 0 8px rgba(77, 171, 247, 0.3);
+  }
 
-    .form-label {
-        color: #ccc;
-    }
+  .form-label {
+    color: #ccc;
+  }
 
-    .form-submit {
-        background: linear-gradient(135deg, #4dabf7, #1976d2);
-    }
+  .form-submit {
+    background: linear-gradient(135deg, #4dabf7, #1976d2);
+  }
 
-    .form-submit:hover {
-        background: linear-gradient(135deg, #3d8bc6, #0d47a1);
-    }
+  .form-submit:hover {
+    background: linear-gradient(135deg, #3d8bc6, #0d47a1);
+  }
 
-    .form-clear {
-        background: linear-gradient(135deg, #f44336, #b71c1c);
-    }
+  .form-clear {
+    background: linear-gradient(135deg, #f44336, #b71c1c);
+  }
 
-    .form-clear:hover {
-        background: linear-gradient(135deg, #d32f2f, #8c1515);
-    }
+  .form-clear:hover {
+    background: linear-gradient(135deg, #d32f2f, #8c1515);
+  }
 
-    .error-message {
-        color: #f44336;
-    }
+  .error-message {
+    color: #f44336;
+  }
 
-    input[readonly] {
-        background-color: #444;
-    }
+  input[readonly] {
+    background-color: #444;
+  }
+}
+
+/* ==========================================================================
+   Copy Button Styles
+   ========================================================================== */
+.input-copy-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.copy-button {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  padding: 4px;
+  color: #666;
+}
+
+.input-copy-container:hover .copy-button {
+  opacity: 1;
+}
+
+.copy-button:hover {
+  color: #1a73e8;
+}
+
+.copy-button:focus {
+  outline: 3px solid #1a73e8;
+  outline-offset: 2px;
+  opacity: 1;
+}
+
+.copy-icon {
+  width: 16px;
+  height: 16px;
+  vertical-align: middle;
+}
+
+.copy-tooltip {
+  position: absolute;
+  top: -30px;
+  right: 0;
+  background-color: #333;
+  color: #fff;
+  font-size: 0.8rem;
+  padding: 2px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+  font-family: inherit;
+  line-height: normal; /* Prevent text alignment issues */
+}
+
+.copy-button:hover .copy-tooltip,
+.copy-button.copied .copy-tooltip {
+  opacity: 1;
+}
+
+.copy-tooltip::before {
+  content: "Copy";
+}
+
+.copy-button.copied .copy-tooltip::before {
+  content: "Copied!";
+}
+
+/* Dark Mode for Copy Button */
+@media (prefers-color-scheme: dark) {
+  .copy-button {
+    color: #b0b0b0;
+  }
+
+  .copy-button:hover {
+    color: #4dabf7;
+  }
+
+  .copy-tooltip {
+    background-color: #444;
+    color: #e0e0e0;
+  }
+
+  .copy-button:focus {
+    outline: 3px solid #4dabf7;
+  }
+}
+
+/* Accessibility for Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+  .copy-button,
+  .copy-tooltip {
+    transition: none;
+  }
 }

--- a/internal/ui/home.templ
+++ b/internal/ui/home.templ
@@ -12,30 +12,64 @@ templ HomeContent() {
 	<p class="app-description">Enter a MAC address and IPv6 prefix to calculate the EUI-64 address.</p>
 	<div class="form-fields">
 		<form hx-post="/calculate" hx-target=".result-container" hx-swap="innerHTML">
-			<label class="form-label" for="mac">MAC Address</label>
-			<input
-				type="text"
-				class="form-field"
-				placeholder="xx-xx-xx-xx-xx-xx or xx:xx:xx:xx:xx:xx"
-				id="mac"
-				name="mac"
-				maxlength="17"
-				pattern="[0-9a-fA-F]{2}([-:][0-9a-fA-F]{2}){5}"
-				title="MAC address must be in format xx-xx-xx-xx-xx-xx or xx:xx:xx:xx:xx:xx (e.g., 00-14-22-01-23-45 or 00:14:22:01:23:45)"
-				required
-			/>
-			<label class="form-label" for="ip-start">Start of IPv6 Address</label>
-			<input
-				type="text"
-				class="form-field"
-				placeholder="xxxx:xxxx:xxxx:xxxx"
-				id="ip-start"
-				name="ip-start"
-				maxlength="19"
-				pattern="^([0-9a-fA-F]{0,4}:){0,3}[0-9a-fA-F]{0,4}$"
-				title="IPv6 prefix must be up to 4 hextets (e.g., 2001:db8::)"
-				required
-			/>
+			<div class="form-field-container">
+				<label class="form-label" for="mac">MAC Address</label>
+				<div class="input-copy-container">
+					<input
+						type="text"
+						class="form-field"
+						placeholder="xx-xx-xx-xx-xx-xx or xx:xx:xx:xx:xx:xx"
+						id="mac"
+						name="mac"
+						maxlength="17"
+						pattern="[0-9a-fA-F]{2}([-:][0-9a-fA-F]{2}){5}"
+						title="MAC address must be in format xx-xx-xx-xx-xx-xx or xx:xx:xx:xx:xx:xx (e.g., 00-14-22-01-23-45 or 00:14:22:01:23:45)"
+						aria-describedby="mac-copy"
+						required
+					/>
+					<button type="button" class="copy-button" id="copy-mac" aria-label="Copy MAC Address">
+						<svg class="copy-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+							<rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+							<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+						</svg>
+						<span class="copy-tooltip"></span>
+					</button>
+					<script>
+						document.getElementById("copy-mac").addEventListener("click", () => {
+							copyToClipboard("mac", "copy-mac");
+						});
+					</script>
+				</div>
+			</div>
+			<div class="form-field-container">
+				<label class="form-label" for="ip-start">Start of IPv6 Address</label>
+				<div class="input-copy-container">
+					<input
+						type="text"
+						class="form-field"
+						placeholder="xxxx:xxxx:xxxx:xxxx"
+						id="ip-start"
+						name="ip-start"
+						maxlength="19"
+						pattern="^([0-9a-fA-F]{0,4}:){0,3}[0-9a-fA-F]{0,4}$"
+						title="IPv6 prefix must be up to 4 hextets (e.g., 2001:db8::)"
+						aria-describedby="ip-start-copy"
+						required
+					/>
+					<button type="button" class="copy-button" id="copy-ip-start" aria-label="Copy IPv6 Prefix">
+						<svg class="copy-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+							<rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+							<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+						</svg>
+						<span class="copy-tooltip"></span>
+					</button>
+					<script>
+						document.getElementById("copy-ip-start").addEventListener("click", () => {
+							copyToClipboard("ip-start", "copy-ip-start");
+						});
+					</script>
+				</div>
+			</div>
 			<div class="form-buttons">
 				<button type="submit" class="form-submit">Calculate</button>
 				<button type="reset" class="form-clear">Clear</button>

--- a/internal/ui/layout.templ
+++ b/internal/ui/layout.templ
@@ -12,7 +12,6 @@ templ Layout(title string, content templ.Component) {
 			<title>{ title }</title>
 			<link rel="icon" href="/static/favicon.ico" type="image/x-icon"/>
 			<link rel="stylesheet" href="/static/styles.css"/>
-			<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet"/>
 			<script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
 		</head>
 		<body>
@@ -20,15 +19,27 @@ templ Layout(title string, content templ.Component) {
 				@content
 			</div>
 			<script>
-			document.body.addEventListener('htmx:afterSwap', function(event) {
-				const formResults = document.querySelector('.form-results');
-				const resultContainer = document.querySelector('.result-container');
-				if (formResults && resultContainer && resultContainer.innerHTML.trim() !== '') {
-					formResults.classList.remove('hidden');
-					resultContainer.classList.remove('hidden');
+				function copyToClipboard(elementId, buttonId) {
+					const input = document.getElementById(elementId);
+					const button = document.getElementById(buttonId);
+					navigator.clipboard.writeText(input.value).then(() => {
+						button.classList.add('copied');
+						setTimeout(() => {
+							button.classList.remove('copied');
+						}, 2000); // Remove "Copied!" after 2 seconds
+					}).catch(err => {
+						console.error('Failed to copy: ', err);
+					});
 				}
-			});
-		</script>
+				document.body.addEventListener('htmx:afterSwap', function(event) {
+					const formResults = document.querySelector('.form-results');
+					const resultContainer = document.querySelector('.result-container');
+					if (formResults && resultContainer && resultContainer.innerHTML.trim() !== '') {
+						formResults.classList.remove('hidden');
+						resultContainer.classList.remove('hidden');
+					}
+				});
+			</script>
 		</body>
 	</html>
 }

--- a/internal/ui/result.templ
+++ b/internal/ui/result.templ
@@ -13,10 +13,42 @@ templ Result(data ResultData) {
 	if data.Error != "" {
 		<p class="error-message">{ data.Error }</p>
 	} else {
-		<label class="form-label" for="ip">End of IPv6 Address</label>
-		<input type="text" class="form-field" readonly value={ data.InterfaceID }/>
+		<div class="form-field-container">
+			<label class="form-label" for="interface-id">End of IPv6 Address</label>
+			<div class="input-copy-container">
+				<input type="text" class="form-field" id="interface-id" readonly value={ data.InterfaceID } aria-describedby="interface-id-copy"/>
+				<button class="copy-button" id="copy-interface" aria-label="Copy Interface ID">
+					<svg class="copy-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+						<rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+						<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+					</svg>
+					<span class="copy-tooltip"></span>
+				</button>
+				<script>
+					document.getElementById("copy-interface").addEventListener("click", () => {
+						copyToClipboard("interface-id", "copy-interface");
+					});
+				</script>
+			</div>
+		</div>
 		<br/>
-		<label class="form-label" for="ip-full">IPv6 Address</label>
-		<input type="text" class="form-field" readonly value={ data.FullIP }/>
+		<div class="form-field-container">
+			<label class="form-label" for="ip-full">IPv6 Address</label>
+			<div class="input-copy-container">
+				<input type="text" class="form-field" id="ip-full" readonly value={ data.FullIP } aria-describedby="ip-full-copy"/>
+				<button class="copy-button" id="copy-ip-full" aria-label="Copy IPv6 Address">
+					<svg class="copy-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+						<rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+						<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+					</svg>
+					<span class="copy-tooltip"></span>
+				</button>
+				<script>
+					document.getElementById("copy-ip-full").addEventListener("click", () => {
+						copyToClipboard("ip-full", "copy-ip-full");
+					});
+				</script>
+			</div>
+		</div>
 	}
 }


### PR DESCRIPTION
**Description**
Adds copy buttons to the EUI-64 Calculator UI for MAC Address and IPv6 Prefix inputs, and Interface ID and IPv6 Address results. Buttons use a code-block-like design with SVG icons and tooltips ("Copy" on hover, "Copied!" on click). Removes Google Fonts, using a system font stack for performance and privacy. Ensures accessibility and consistency in light and dark modes.

**Key Changes**
- Add copy buttons to `home.templ` for MAC Address and IPv6 Prefix inputs, and to `result.templ` for Interface ID and IPv6 Address results.
- Define `copyToClipboard` function in `layout.templ` for shared use.
- Update `styles.css` to style copy buttons with system font stack.
- Remove Google Fonts from `layout.templ` and `styles.css`.
- Update `ui_test.go` to test copy buttons and fix Google Fonts and result field label tests.