### PR TITLE
ci: utilize cosign action installer

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,6 +58,9 @@ jobs:
       - name: Generate templates
         run: go generate ./...
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.9.2
+
       - name: Set up QEMU # Enable multi-platform emulation.
         uses: docker/setup-qemu-action@05340d1c670183e7caabdb33ae9f1c80fae3b0c2
         with:
@@ -107,11 +110,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_NAMESPACE: ${{ inputs.docker_namespace }}
           GHCR_NAMESPACE: ${{ inputs.ghcr_namespace }}
-
-      - name: Install Cosign
-        run: |
-          curl -sSfL https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64 -o /usr/local/bin/cosign
-          chmod +x /usr/local/bin/cosign
 
       - name: Sign Docker Images with Cosign (Keyless)
         run: |

--- a/.github/workflows/create-manifests.yaml
+++ b/.github/workflows/create-manifests.yaml
@@ -74,9 +74,7 @@ jobs:
             ghcr.io/${{ inputs.ghcr_namespace }}/${{ inputs.project_name }}:riscv64-latest
 
       - name: Install Cosign
-        run: |
-          curl -sSfL https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64 -o /usr/local/bin/cosign
-          chmod +x /usr/local/bin/cosign
+        uses: sigstore/cosign-installer@v3.9.2
 
       - name: Sign Docker Manifests with Cosign (Keyless)
         run: |


### PR DESCRIPTION
Use the Cosign installer GitHub action instead of a manual binary install step.

This is expected to resolve issues of OIDC handling.