### PR TITLE
feat(gh-pages): Add WASM-based static site deployment for GitHub Pages

### DIFF
--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   workflow_dispatch: {}
+  workflow_call: {}
 
 permissions:
   contents: write
@@ -30,8 +31,8 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          key: "${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}"
+          restore-keys: "${{ runner.os }}-go-"
 
       - name: Install templ
         run: go install github.com/a-h/templ/cmd/templ@v0.3.924
@@ -51,12 +52,12 @@ jobs:
       - name: Build WASM
         run: GOOS=js GOARCH=wasm go build -o dist/static/main.wasm ./build/gh-pages/wasm/main.go
 
-      - name: Copy and minify static assets to root
+      - name: Copy and minify static assets
         run: |
           mkdir -p dist/static
           cp dist/static/index.html dist/static/
           cp dist/static/main.wasm dist/static/
-          cp $GOROOT/misc/wasm/wasm_exec.js dist/static/
+          cp "$GOROOT/misc/wasm/wasm_exec.js" dist/static/
           cp cmd/server/static/styles.css dist/static/
           cp cmd/server/static/favicon.ico dist/static/
           cp build/gh-pages/static/scripts.js dist/static/

--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -1,0 +1,74 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  packages: read
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@1d76b952eb9246b03e20e15a9ef98c6d4af389ef
+        with:
+          go-version: 1.25.x
+
+      - name: Cache Go modules
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
+
+      - name: Install templ
+        run: go install github.com/a-h/templ/cmd/templ@v0.3.924
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Generate templates
+        run: go generate ./...
+
+      - name: Build static-gen
+        run: go build -o static-gen ./build/gh-pages/static-gen/main.go
+
+      - name: Generate index.html
+        run: ./static-gen
+
+      - name: Build WASM
+        run: GOOS=js GOARCH=wasm go build -o dist/static/main.wasm ./build/gh-pages/wasm/main.go
+
+      - name: Copy and minify static assets to root
+        run: |
+          mkdir -p dist/static
+          cp dist/static/index.html dist/static/
+          cp dist/static/main.wasm dist/static/
+          cp $GOROOT/misc/wasm/wasm_exec.js dist/static/
+          cp cmd/server/static/styles.css dist/static/
+          cp cmd/server/static/favicon.ico dist/static/
+          cp build/gh-pages/static/scripts.js dist/static/
+          # Minify scripts.js and styles.css
+          npx uglify-js dist/static/scripts.js -o dist/static/scripts.js
+          npx cssnano < dist/static/styles.css > dist/static/styles.min.css
+          mv dist/static/styles.min.css dist/static/styles.css
+          # Add .nojekyll to disable Jekyll
+          touch dist/static/.nojekyll
+
+      - name: Deploy to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: dist/static

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,16 @@ jobs:
       docker_namespace: nickfedor
       ghcr_namespace: nicholas-fedor
 
+  deploy-gh-pages:
+    name: Deploy to GitHub Pages
+    needs:
+      - test
+      - lint
+    permissions:
+      contents: write
+    secrets: inherit
+    uses: ./.github/workflows/deploy-gh-pages.yaml
+
   Update-Go-Docs:
     name: Update Go docs
     needs:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+static-gen
 
 # Test binary, built with `go test -c`
 *.test

--- a/build/gh-pages/static/scripts.js
+++ b/build/gh-pages/static/scripts.js
@@ -1,0 +1,159 @@
+// Initializes WebAssembly module and handles form interactions for the EUI-64 calculator static site.
+const go = new Go();
+WebAssembly.instantiateStreaming(fetch("./main.wasm"), go.importObject)
+  .then((result) => {
+    go.run(result.instance);
+    console.log("WebAssembly module loaded successfully");
+    // Verify WebAssembly functions are available
+    if (
+      typeof window.validateMAC !== "function" ||
+      typeof window.validateIPv6Prefix !== "function" ||
+      typeof window.calculateEUI64 !== "function"
+    ) {
+      console.error("WebAssembly functions not available");
+    }
+  })
+  .catch((err) => console.error("WASM load error:", err));
+
+// copyToClipboard copies the value of an input element to the clipboard and updates the button's tooltip.
+// It matches the behavior in ui/layout.templ, displaying "Copied!" for 2 seconds on success.
+function copyToClipboard(elementId, buttonId) {
+  const input = document.getElementById(elementId);
+  const button = document.getElementById(buttonId);
+  if (!input || !button) {
+    console.error(
+      `copyToClipboard: Element ${elementId} or ${buttonId} not found`
+    );
+    return;
+  }
+  navigator.clipboard
+    .writeText(input.value)
+    .then(() => {
+      button.classList.add("copied");
+      const tooltip = button.querySelector(".copy-tooltip");
+      tooltip.textContent = "Copied!";
+      setTimeout(() => {
+        button.classList.remove("copied");
+        tooltip.textContent = "Copy";
+      }, 2000);
+    })
+    .catch((err) => {
+      console.error("Failed to copy: ", err);
+    });
+}
+
+// Initializes form event listeners for submission and clearing, handling validation and calculation via WASM.
+document.addEventListener("DOMContentLoaded", () => {
+  const form = document.querySelector("form");
+  const resultContainer = document.querySelector(".result-container");
+  const formResults = document.querySelector(".form-results");
+  const macInput = document.getElementById("mac");
+  const prefixInput = document.getElementById("ip-start");
+  const copyMac = document.getElementById("copy-mac");
+  const copyPrefix = document.getElementById("copy-ip-start");
+
+  if (
+    !form ||
+    !resultContainer ||
+    !formResults ||
+    !macInput ||
+    !prefixInput ||
+    !copyMac ||
+    !copyPrefix
+  ) {
+    console.error("Required DOM elements not found");
+    return;
+  }
+
+  console.log("Form event listeners initialized");
+
+  copyMac.addEventListener("click", () => copyToClipboard("mac", "copy-mac"));
+  copyPrefix.addEventListener("click", () =>
+    copyToClipboard("ip-start", "copy-ip-start")
+  );
+
+  form.addEventListener("submit", (e) => {
+    e.preventDefault(); // Prevent default form submission
+    console.log("Form submitted");
+    resultContainer.innerHTML = "";
+    formResults.classList.remove("hidden");
+
+    const mac = macInput.value;
+    const prefix = prefixInput.value;
+
+    // Check if WebAssembly functions are available
+    if (typeof window.validateMAC !== "function") {
+      resultContainer.innerHTML = `<p class="error-message">Error: WebAssembly module not loaded</p>`;
+      resultContainer.classList.remove("hidden");
+      return;
+    }
+
+    let macErr = window.validateMAC(mac);
+    if (macErr) {
+      resultContainer.innerHTML = `<p class="error-message">Please enter a valid MAC address (e.g., 00-14-22-01-23-45): ${macErr}</p>`;
+      resultContainer.classList.remove("hidden");
+      return;
+    }
+    let prefixErr = window.validateIPv6Prefix(prefix);
+    if (prefixErr) {
+      resultContainer.innerHTML = `<p class="error-message">Please enter a valid IPv6 prefix (e.g., 2001:db8::): ${prefixErr}</p>`;
+      resultContainer.classList.remove("hidden");
+      return;
+    }
+
+    let result = window.calculateEUI64(mac, prefix);
+    if (typeof result === "string") {
+      resultContainer.innerHTML = `<p class="error-message">Failed to calculate EUI-64 address: ${result}</p>`;
+      resultContainer.classList.remove("hidden");
+      return;
+    }
+
+    // Render result HTML, matching ui/result.templ structure and behavior.
+    resultContainer.innerHTML = `
+            <div class="form-field-container">
+                <label class="form-label" for="interface-id">End of IPv6 Address</label>
+                <div class="input-copy-container">
+                    <input type="text" class="form-field" id="interface-id" readonly value="${result.interfaceID}" aria-describedby="interface-id-copy"/>
+                    <button class="copy-button" id="copy-interface" aria-label="Copy Interface ID">
+                        <svg class="copy-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                        </svg>
+                        <span class="copy-tooltip">Copy</span>
+                    </button>
+                    <script>
+                        document.getElementById("copy-interface").addEventListener("click", () => {
+                            copyToClipboard("interface-id", "copy-interface");
+                        });
+                    </script>
+                </div>
+            </div>
+            <br/>
+            <div class="form-field-container">
+                <label class="form-label" for="ip-full">IPv6 Address</label>
+                <div class="input-copy-container">
+                    <input type="text" class="form-field" id="ip-full" readonly value="${result.fullIP}" aria-describedby="ip-full-copy"/>
+                    <button class="copy-button" id="copy-ip-full" aria-label="Copy IPv6 Address">
+                        <svg class="copy-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                        </svg>
+                        <span class="copy-tooltip">Copy</span>
+                    </button>
+                    <script>
+                        document.getElementById("copy-ip-full").addEventListener("click", () => {
+                            copyToClipboard("ip-full", "copy-ip-full");
+                        });
+                    </script>
+                </div>
+            </div>
+        `;
+    resultContainer.classList.remove("hidden");
+  });
+
+  document.querySelector(".form-clear").addEventListener("click", () => {
+    resultContainer.innerHTML = "";
+    formResults.classList.add("hidden");
+    resultContainer.classList.add("hidden");
+  });
+});

--- a/build/gh-pages/wasm/main.go
+++ b/build/gh-pages/wasm/main.go
@@ -1,0 +1,71 @@
+//go:build js && wasm
+// +build js,wasm
+
+// Package main provides a WebAssembly module for client-side EUI-64 calculations.
+// It exposes functions to validate MAC addresses, IPv6 prefixes, and compute EUI-64
+// identifiers, integrating with the browser's JavaScript environment.
+package main
+
+import (
+	"syscall/js"
+
+	"github.com/nicholas-fedor/eui64-calculator/internal/eui64"
+	"github.com/nicholas-fedor/eui64-calculator/internal/validators"
+)
+
+// main initializes the WebAssembly module, registering JavaScript functions and
+// keeping the module alive in the browser event loop.
+func main() {
+	js.Global().Set("validateMAC", js.FuncOf(validateMACFunc))
+	js.Global().Set("validateIPv6Prefix", js.FuncOf(validateIPv6PrefixFunc))
+	js.Global().Set("calculateEUI64", js.FuncOf(calculateEUI64Func))
+	<-make(chan bool) // Block indefinitely to keep WASM module active.
+}
+
+// validateMACFunc validates a MAC address string provided via JavaScript.
+// It expects a single string argument and returns an empty string on success or
+// an error message on failure.
+func validateMACFunc(this js.Value, args []js.Value) any {
+	if len(args) != 1 {
+		return "Invalid number of arguments"
+	}
+	mac := args[0].String()
+	if err := validators.ValidateMAC(mac); err != nil {
+		return err.Error()
+	}
+	return ""
+}
+
+// validateIPv6PrefixFunc validates an IPv6 prefix string provided via JavaScript.
+// It expects a single string argument and returns an empty string on success or
+// an error message on failure.
+func validateIPv6PrefixFunc(this js.Value, args []js.Value) any {
+	if len(args) != 1 {
+		return "Invalid number of arguments"
+	}
+	prefix := args[0].String()
+	if err := validators.ValidateIPv6Prefix(prefix); err != nil {
+		return err.Error()
+	}
+	return ""
+}
+
+// calculateEUI64Func computes the EUI-64 interface ID and full IPv6 address from
+// a MAC address and IPv6 prefix provided via JavaScript. It expects two string
+// arguments (MAC and prefix) and returns a JavaScript object with "interfaceID"
+// and "fullIP" fields on success, or an error message on failure.
+func calculateEUI64Func(this js.Value, args []js.Value) any {
+	if len(args) != 2 {
+		return "Invalid number of arguments"
+	}
+	mac := args[0].String()
+	prefix := args[1].String()
+	interfaceID, fullIP, err := eui64.CalculateEUI64(mac, prefix)
+	if err != nil {
+		return err.Error()
+	}
+	return js.ValueOf(map[string]interface{}{
+		"interfaceID": interfaceID,
+		"fullIP":      fullIP,
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/a-h/templ v0.3.943
 	github.com/gin-gonic/gin v1.10.1
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/net v0.43.0
 )
 
 require (
@@ -33,7 +34,6 @@ require (
 	github.com/ugorji/go/codec v1.3.0 // indirect
 	golang.org/x/arch v0.20.0 // indirect
 	golang.org/x/crypto v0.41.0 // indirect
-	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 	google.golang.org/protobuf v1.36.7 // indirect


### PR DESCRIPTION
This PR adds support for a static version of the EUI-64 calculator hosted on GitHub Pages, using WebAssembly for client-side calculations. The static site is generated from the existing UI templates, ensuring no duplication, and deployed to the gh-pages branch.

### Changes
- **WASM Module**: Added `build/gh-pages/wasm/main.go` to expose validation and calculation functions to JavaScript.
- **Static HTML Generation**: Added `build/gh-pages/static-gen/main.go` to render templates, remove HTMX, and format HTML.
- **Client-Side Script**: Added `build/gh-pages/static/scripts.js` for form handling and WASM integration.
- **CI Workflow**: Added `.github/workflows/deploy-gh-pages.yaml` to build and deploy static assets on push to main or manual trigger.
- **Deployment**: Assets deployed to root of gh-pages for simple URL structure.