### PR TITLE
ci: add missing permission

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,7 @@ jobs:
     permissions:
       contents: read # For code checkout
       packages: write # For pushing manifests
+      id-token: write
     secrets: inherit
     uses: ./.github/workflows/create-manifests.yaml
     with:


### PR DESCRIPTION
- Add id-token: write permission to match with create-manifest workflow