### PR TITLE
test: fix missing Host header in HTTP requests

### DIFF
--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -97,12 +97,12 @@ func TestRouterSetup(t *testing.T) {
 				req, _ = http.NewRequestWithContext(
 					context.Background(),
 					tt.method,
-					tt.path,
+					"http://localhost"+tt.path,
 					strings.NewReader(tt.formData.Encode()),
 				)
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 			} else {
-				req, _ = http.NewRequestWithContext(context.Background(), tt.method, tt.path, http.NoBody)
+				req, _ = http.NewRequestWithContext(context.Background(), tt.method, "http://localhost"+tt.path, http.NoBody)
 			}
 
 			resp, err := app.Test(req)
@@ -179,7 +179,7 @@ func TestTrustedProxies(t *testing.T) {
 			req, err := http.NewRequestWithContext(
 				context.Background(),
 				http.MethodGet,
-				"/test-ip",
+				"http://localhost/test-ip",
 				http.NoBody,
 			)
 			require.NoError(t, err)

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -49,7 +49,7 @@ func TestHomeHandler(t *testing.T) {
 			t.Parallel()
 			app := setupRouter(t)
 
-			req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody)
+			req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://localhost/", http.NoBody)
 			resp, err := app.Test(req)
 			require.NoError(t, err)
 
@@ -104,7 +104,7 @@ func TestCalculateHandlerValid(t *testing.T) {
 			req, _ := http.NewRequestWithContext(
 				t.Context(),
 				http.MethodPost,
-				"/calculate",
+				"http://localhost/calculate",
 				strings.NewReader(tt.formData.Encode()),
 			)
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -190,7 +190,7 @@ func TestCalculateHandlerInvalid(t *testing.T) {
 			req, _ := http.NewRequestWithContext(
 				t.Context(),
 				http.MethodPost,
-				"/calculate",
+				"http://localhost/calculate",
 				strings.NewReader(tt.formData.Encode()),
 			)
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")


### PR DESCRIPTION
Tests were failing because Fiber v3 requires a Host header in HTTP/1.1 requests, but the test code was creating requests without it.

## Problem

Multiple test suites (`TestRouterSetup`, `TestTrustedProxies`, `TestHomeHandler`, `TestCalculateHandler*`) were failing with "missing required Host header in request" errors. Fiber v3 enforces HTTP/1.1 compliance which requires the Host header.

## Solution

Updated all test HTTP requests to use full URLs (e.g., `http://localhost/path`) instead of relative paths (`/path`). This ensures the Host header is automatically included when requests are created with `http.NewRequestWithContext`.

## Changes

- Modified `cmd/server/main_test.go` to use full URLs in TestRouterSetup and TestTrustedProxies
- Modified `internal/handlers/handlers_test.go` to use full URLs in TestHomeHandler and TestCalculateHandler* test suites
- All test suites now pass successfully