### PR TITLE
ci(gh-pages): move permissions to job level

### DIFF
--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -7,13 +7,15 @@ on:
   workflow_call: {}
 
 permissions:
-  contents: write
-  packages: read
-  id-token: write
+  contents: read
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
+      id-token: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0


### PR DESCRIPTION
This relocates permissions to job level and sets read only top-level permissions for the GitHub Pages deployment workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment workflow security by adjusting permission scopes, moving elevated permissions to the deployment job level while reducing unnecessary top-level access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->