### PR TITLE
ci: update workflow permissions

### DIFF
--- a/.github/workflows/clean-cache.yaml
+++ b/.github/workflows/clean-cache.yaml
@@ -6,12 +6,14 @@ on:
       - closed
 
 permissions:
-  actions: write
   contents: read
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,18 +12,11 @@ jobs:
   # Run Go tests and upload coverage
   test:
     uses: ./.github/workflows/test.yaml
-    permissions:
-      contents: read # For code checkout
 
   # Build binaries, images, SBOMs, and attestations
   build:
     needs: [test] # Requires tests to pass
     uses: ./.github/workflows/build.yaml
-    permissions:
-      contents: write # For code checkout and publishing releases
-      packages: write # For pushing images to registries
-      attestations: write # For generating provenance and SBOMs
-      id-token: write # For OIDC auth to Docker Hub and GHCR
     with:
       project_name: eui64-calculator
       docker_namespace: nickfedor
@@ -34,10 +27,6 @@ jobs:
     name: Deploy to GitHub Pages
     needs:
       - test
-    permissions:
-      contents: write
-      packages: read
-      id-token: write
     uses: ./.github/workflows/deploy-gh-pages.yaml
 
   Update-Go-Docs:
@@ -45,6 +34,4 @@ jobs:
     needs:
       - test
       - build
-    permissions:
-      contents: read
     uses: ./.github/workflows/update-go-docs.yaml


### PR DESCRIPTION
The clean-cache and release workflows had improper top-level write permissions and permissions improerly passed to workflows that already have jobs that request the necessary permissions.

This PR should hopefully clean things up without breaking anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined internal continuous integration workflow permissions configuration to optimize build and deployment process management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->