### PR TITLE
ci: enable docker secrets passthrough from build to release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,11 @@ on:
         description: "GitHub environment for secrets access"
         required: true
         type: string
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
-permissions: {}  # No global permissions; jobs declare only what they need
+permissions: {} # No global permissions; jobs declare only what they need
 
 jobs:
   # Run Go tests and upload coverage
@@ -28,6 +28,9 @@ jobs:
       docker_namespace: nickfedor
       ghcr_namespace: nicholas-fedor
       environment: CI
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   deploy-gh-pages:
     name: Deploy to GitHub Pages


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to enhance Docker Hub authentication handling during the build and release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->