### PR TITLE
ci(build): add sbom attestation subject-checksums path

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -133,6 +133,7 @@ jobs:
       - name: Generate SBOM attestation
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
+          subject-checksums: ./dist/checksums.txt
           sbom-path: ./dist/*.sbom.json
 
       - name: Generate artifact attestation for checksums


### PR DESCRIPTION
This should hopefully resolve the following error:

Error: One of subject-path, subject-digest, or subject-checksums must be provided

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration to enhance attestation verification alignment.

---

**Note:** This release contains infrastructure improvements with no direct user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->