### PR TITLE
ci(actionlint): refactor workflow to use actionlint-action

### DIFF
--- a/.github/workflows/lint-gh.yaml
+++ b/.github/workflows/lint-gh.yaml
@@ -1,10 +1,8 @@
-name: Lint GitHub Actions workflows
+---
+name: Lint GitHub Actions Workflows
 
 on:
   workflow_dispatch: {}
-  push:
-    paths:
-      - ".github/workflows/**"
   pull_request:
     branches:
       - main
@@ -12,29 +10,21 @@ on:
       - ".github/workflows/**"
 
 permissions:
-  contents: read
+  contents: read # Set default read-only permissions
 
 jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: Harden the Runner (Step Security)
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: audit
 
-      - name: Checkout
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - name: Download actionlint
-        id: get_actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-        shell: bash
-
-      - name: Check workflow files
-        run: ${STEPS_GET_ACTIONLINT_OUTPUTS_EXECUTABLE} -color
-        shell: bash
-        env:
-          STEPS_GET_ACTIONLINT_OUTPUTS_EXECUTABLE: ${{ steps.get_actionlint.outputs.executable }}
+      - name: Run actionlint
+        uses: nicholas-fedor/actionlint-action@cfb3d059a17ba00c4b5717a9fa057fa434abb44f # v1.0.3


### PR DESCRIPTION
- Replace manual actionlint download with nicholas-fedor/actionlint-action
- Remove push trigger, keep workflow_dispatch and pull_request triggers
- Update checkout action to v6.0.2
- Rename steps for clarity and consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to optimize linting processes with refined trigger conditions for pull requests and improved execution using a dedicated third-party action.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nicholas-fedor/eui64-calculator/pull/758)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->