### PR TITLE
chore(ci): update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,13 +49,13 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Full history for GoReleaser versioning.
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
           cache: false
@@ -80,13 +80,13 @@ jobs:
         run: go generate ./...
 
       - name: Set up QEMU # Enable multi-platform emulation.
-        uses: docker/setup-qemu-action@f4e8deed0c3c26542279f4042c0e1d059cbf012d
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
         with:
           image: tonistiigi/binfmt@sha256:d3b963f787999e6c0219a48dba02978769286ff61a5f4d26245cb6a6e5567ea3
           platforms: linux/amd64,linux/386,linux/arm/v6,linux/arm64/v8,linux/riscv64
 
       - name: Set up Docker Buildx # Configure multi-platform builds.
-        uses: docker/setup-buildx-action@21162887f0d6e25b4e8eafb0cf44cf9bf7f6acd3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
         with:
           platforms: linux/amd64,linux/386,linux/arm/v6,linux/arm64/v8,linux/riscv64
 
@@ -124,7 +124,7 @@ jobs:
           GHCR_NAMESPACE: ${{ inputs.ghcr_namespace }}
 
       - name: Upload binary SBOMs
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary-sboms
           path: ./dist/*.sbom.json

--- a/.github/workflows/changelog-update.yaml
+++ b/.github/workflows/changelog-update.yaml
@@ -24,7 +24,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -41,7 +41,7 @@ jobs:
 
       - name: Create Pull Request for Changelog
         id: create_pr
-        uses: peter-evans/create-pull-request@d32e88dac789dcc7906e7d26f69f24116fa9c97d
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: docs/update-changelog

--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -23,18 +23,18 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
 
       - name: Cache Go modules
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -18,12 +18,12 @@ jobs:
           egress-policy: audit
 
       - name: Checkout code
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
 
@@ -37,7 +37,7 @@ jobs:
         run: go generate ./...
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@46c9287ccb5fd9a896cb5705a7012084e34f6736
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           args: --timeout=5m --config=build/golangci-lint/golangci-lint.yaml
 

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -35,7 +35,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout Source
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Run Gosec Security Scanner

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,13 +23,13 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
           cache: true
@@ -51,6 +51,6 @@ jobs:
           go test -v -coverprofile coverage.out -covermode atomic ./...
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/update-go-docs.yaml
+++ b/.github/workflows/update-go-docs.yaml
@@ -17,4 +17,4 @@ jobs:
           egress-policy: audit
 
       - name: Pull new module version
-        uses: nicholas-fedor/go-proxy-pull-action@6568a554a1ba0271d4b6641a767e7c9aa6011b6a
+        uses: nicholas-fedor/go-proxy-pull-action@8cd893d777f54cecfde41e420c6abfd4fbca8826 # v1.1.0


### PR DESCRIPTION
- Update actions/checkout to v6.0.2 across all workflows
- Update actions/setup-go to v6.4.0 and add version comments
- Update actions/cache to v5.0.5 in deploy-gh-pages workflow
- Update actions/upload-artifact to v7.0.1 in build workflow
- Update docker/setup-qemu-action to v4.0.0 in build workflow
- Update docker/setup-buildx-action to v4.1.0 in build workflow
- Update peter-evans/create-pull-request to v8.1.1 in changelog-update workflow
- Update golangci/golangci-lint-action to v9.2.1 in lint-go workflow
- Update codecov/codecov-action to v6.0.1 in test workflow
- Update nicholas-fedor/go-proxy-pull-action to v1.1.0 in update-go-docs workflow
- Add missing version tags to action references for consistency