### PR TITLE
chore(codeowners): reorganize with granular path ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,28 @@
-* @nicholas-fedor
+# Source code
+cmd/                    @nicholas-fedor
+internal/               @nicholas-fedor
+main.go                 @nicholas-fedor
 
-# Automated changelog updates — no manual approval needed
-CHANGELOG.md    @github-actions[bot]
+# Build and task configuration
+Makefile                @nicholas-fedor
+Taskfile.yml            @nicholas-fedor
+build/                  @nicholas-fedor
+
+# CI/CD and tool configuration
+.github/                @nicholas-fedor
+.circleci/              @nicholas-fedor
+cliff.toml              @nicholas-fedor
+commitlint.config.cjs   @nicholas-fedor
+.codacy.yml             @nicholas-fedor
+
+# Project configuration
+.all-contributorsrc     @nicholas-fedor
+.gitattributes          @nicholas-fedor
+.gitignore              @nicholas-fedor
+package.json            @nicholas-fedor
+.vscode/                @nicholas-fedor
+
+# Documentation
+README.md               @nicholas-fedor
+LICENSE.md              @nicholas-fedor
+examples/               @nicholas-fedor


### PR DESCRIPTION
This PR updates the `CODEOWNERS` file to use more granular permissions.

## Problem

The use of a wildcard entry resulted in CI/CD automation requiring manual intervention to approve changes.

## Solution

Utilize more granular ownership assignments to avoid shadowing files managed by CI/CD.

## Changes

- Replace wildcard ownership with explicit directory and file assignments
- Group entries by category: source, build, CI/CD, config, and docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository code ownership configuration.

---

**Note:** This is an internal repository maintenance change with no direct impact on user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->