### PR TITLE
ci(build): use syft download action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,8 +93,8 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      - name: Install Syft for SBOM generation # Install Syft for GoReleaser SBOM generation
-        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+      - name: Install Syft for SBOM generation
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Login to Docker Hub # Authenticate to Docker Hub
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4


### PR DESCRIPTION
This PR replaces the Syft installation step with an official installation GitHub Action.

## Problem

The Syft installation step uses curl to download and run their installation script.

## Solution

Replace the download and use of the installation script with Syft's GitHub Action.

## Changes

- Replace binary download step with official action