### PR TITLE
chore(lint): enable goconst linter and extract string constants

### DIFF
--- a/build/golangci-lint/golangci-lint.yaml
+++ b/build/golangci-lint/golangci-lint.yaml
@@ -562,6 +562,7 @@ linters:
           - exhaustruct
           - forcetypeassert
           - funlen
+          - goconst
           - gocyclo
           - gosec
           - promlinter
@@ -606,7 +607,8 @@ linters:
     # Which file paths to exclude: they will be analyzed, but issues from them won't be reported.
     # "/" will be replaced by the current OS file path separator to properly work on Windows.
     # Default: []
-    # paths:
+    paths:
+      - ".*_templ\\.go$"
     # - ".*\\.my\\.go$"
     # - lib/bad.go
     # - ".*/mocks/.*"
@@ -770,9 +772,9 @@ formatters:
     ##################################################################################################
     # Which file paths to exclude.
     # Default: []
-    # paths:
-    # - ".*mocks$"
-    # - ".*_templ.go$"
+    paths:
+      # - ".*mocks$"
+      - ".*_templ\\.go$"
   #   - third_party$
   #   - builtin$
   #   - examples$

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -28,6 +28,12 @@ type Handler struct {
 	calc Calculator // calc is the EUI-64 calculator implementation.
 }
 
+const (
+	errInvalidMACAddress  = "Please enter a valid MAC address (e.g., 00-14-22-01-23-45)"
+	errInvalidIPv6Prefix  = "Please enter a valid IPv6 prefix (e.g., 2001:db8::)"
+	errCalculationFailure = "Failed to calculate EUI-64 address"
+)
+
 // NewHandler creates a new Handler with the specified EUI-64 calculator.
 // It initializes the handler with the provided calculator for dependency injection.
 func NewHandler(calc Calculator) *Handler {
@@ -44,7 +50,7 @@ func (h *Handler) Calculate(c fiber.Ctx) error {
 	data := ui.ResultData{}
 
 	if err := validators.ValidateMAC(mac); err != nil {
-		data.Error = "Please enter a valid MAC address (e.g., 00-14-22-01-23-45)"
+		data.Error = errInvalidMACAddress
 
 		slog.WarnContext(
 			c.Context(),
@@ -57,7 +63,7 @@ func (h *Handler) Calculate(c fiber.Ctx) error {
 	}
 
 	if err := validators.ValidateIPv6Prefix(prefix); err != nil {
-		data.Error = "Please enter a valid IPv6 prefix (e.g., 2001:db8::)"
+		data.Error = errInvalidIPv6Prefix
 
 		slog.WarnContext(
 			c.Context(),
@@ -76,7 +82,7 @@ func (h *Handler) Calculate(c fiber.Ctx) error {
 	data.FullIP = fullIP
 
 	if err != nil {
-		data.Error = "Failed to calculate EUI-64 address"
+		data.Error = errCalculationFailure
 
 		slog.ErrorContext(
 			c.Context(),


### PR DESCRIPTION
- Add goconst to enabled linters in golangci-lint configuration
- Exclude templ generated files from linting and formatting paths
- Extract repeated error message strings to named constants in handlers package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved static analysis configuration to reduce irrelevant warnings in tests and generated files.
  * Preserved existing calculation and validation behavior while standardizing error handling internally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->