### PR TITLE
test(server): correct trusted proxy IP selection test expectation

### DIFF
--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -159,9 +159,9 @@ func TestTrustedProxies(t *testing.T) {
 			wantIP:        "203.0.113.195",
 		},
 		{
-			name:          "Multiple IPs in X-Forwarded-For returns first",
+			name:          "Multiple IPs in X-Forwarded-For returns rightmost non-trusted",
 			xForwardedFor: "203.0.113.195, 70.41.3.18, 150.172.238.178",
-			wantIP:        "203.0.113.195",
+			wantIP:        "150.172.238.178",
 		},
 		{
 			name:          "No X-Forwarded-For header returns remote IP",


### PR DESCRIPTION
- Update test case name to reflect actual behavior
- Fix expected IP to rightmost non-trusted address in X-Forwarded-For header

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected client IP detection when multiple addresses are provided in the `X-Forwarded-For` header, using the rightmost non-trusted address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->